### PR TITLE
use xml output instead of localized svninfo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-svninfo",
   "description": "Subversion working copy metadata (svn info) grunt plugin",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "homepage": "https://github.com/liqweed/grunt-svninfo",
   "author": {
     "name": "liqweed"


### PR DESCRIPTION
Hello,

I had an issue using your grunt-svninfo when I was in a french locale.
I've then fix the problem using the xml output for the 'svn info --xml'.
Please merge my modification and publish a new release on npm.

Thanks :)

Damien

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/liqweed/grunt-svninfo/6)
<!-- Reviewable:end -->
